### PR TITLE
DBZ-3 Creates a docker image to be used with the decoderbufs PG plugin

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -3,6 +3,7 @@
 JAVA_VERSION=8u92
 DEBEZIUM_VERSION=0.3
 MONGO_VERSION=3.2
+POSTGRES_VERSION=9.6
 
 ./build-java.sh $JAVA_VERSION
 if [ $? -ne 0 ]; then
@@ -10,6 +11,11 @@ if [ $? -ne 0 ]; then
 fi
 
 ./build-mongo.sh $MONGO_VERSION
+if [ $? -ne 0 ]; then
+    exit $?;
+fi
+
+./build-postgres.sh $POSTGRES_VERSION
 if [ $? -ne 0 ]; then
     exit $?;
 fi

--- a/build-postgres.sh
+++ b/build-postgres.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+if [[ -z "$1" ]]; then
+    echo ""
+    echo "A version must be specified."
+    echo ""
+    echo "Usage:  build-postgres <version>";
+    echo ""
+    exit 1;
+fi
+
+echo ""
+echo "****************************************************************"
+echo "** Building  debezium/postgres:$1"
+echo "****************************************************************"
+docker build -t debezium/postgres:$1 postgres/$1

--- a/postgres/9.6/Dockerfile
+++ b/postgres/9.6/Dockerfile
@@ -1,0 +1,30 @@
+FROM postgres:9.6
+
+MAINTAINER Debezium Community
+
+# Install the packages which will be required to get everything to compile
+RUN apt-get update \ 
+    && apt-get install -f -y --no-install-recommends \
+        software-properties-common \
+        build-essential \
+        pkg-config \ 
+        git \
+        postgresql-server-dev-9.6 \
+        libproj-dev \
+    && apt-get clean && apt-get update && apt-get install -f -y --no-install-recommends \            
+        liblwgeom-dev \              
+    && add-apt-repository "deb http://ftp.debian.org/debian testing main contrib" \ 
+    && apt-get update && apt-get install -f -y --no-install-recommends \
+        libprotobuf-c-dev=1.2.* \
+    && rm -rf /var/lib/apt/lists/*             
+ 
+# Compile the plugin from sources and install it
+RUN git clone https://github.com/debezium/postgres-decoderbufs -b v0.1.0 --single-branch \
+    && cd /postgres-decoderbufs \ 
+    && make && make install \
+    && cd / \ 
+    && rm -rf postgres-decoderbufs            
+
+# Copy the custom configuration which will be passed down to the server (using a .sample file is the preferred way of doing it by 
+# the base Docker image)
+COPY postgresql.conf.sample /usr/share/postgresql/postgresql.conf.sample

--- a/postgres/9.6/postgresql.conf.sample
+++ b/postgres/9.6/postgresql.conf.sample
@@ -1,0 +1,15 @@
+# LOGGING
+log_min_error_statement = fatal
+
+# CONNECTION
+listen_addresses = '*'
+
+# MODULES
+shared_preload_libraries = 'decoderbufs'
+
+# REPLICATION
+wal_level = logical             # minimal, archive, hot_standby, or logical (change requires restart)
+max_wal_senders = 1             # max number of walsender processes (change requires restart)
+#wal_keep_segments = 4          # in logfile segments, 16MB each; 0 disables
+#wal_sender_timeout = 60s       # in milliseconds; 0 disables
+max_replication_slots = 1       # max number of replication slots (change requires restart)


### PR DESCRIPTION
The docker image uses the base Postgres 9.6 image and [my local decoderbufs fork](https://github.com/hchiorean/decoderbufs). 

The difference between the main repository and my fork is atm.:
* removal of the PostGIS dependency
* change of the Proto Java package names and classes

Ideally this Docker image should use a decoderbufs fork from the main [DBZ repository](https://github.com/debezium) which we can then modify as we see fit.

To validate that the docker image actually works, I've updated my [DBZ-3 branch](https://github.com/hchiorean/debezium/tree/DBZ-3) and the code for the [Postgres connector](https://github.com/hchiorean/debezium/tree/DBZ-3/debezium-connector-postgres) to use the `proto` file from the plugin, generate the appropriate Java classes (via a Maven plugin) and test that the Protobuf deserialization actually works.

The next step in the connector implementation is to get the updated PG driver with the [replication logic](https://github.com/pgjdbc/pgjdbc/pull/550) and implement the connector logic. Hopefully this PR makes it in the next PG driver release.