### PR TITLE
DBZ-127: Adding docker-compose.yml to support 0.3 mysql-connector tutorial

### DIFF
--- a/connect/0.3/docker-compose.yml
+++ b/connect/0.3/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "2.0"
+
+services:
+  zookeeper:
+    image: debezium/zookeeper:0.3
+    container_name: zookeeper
+    ports: 
+      - "2181:2181"
+      - "2888:2888"
+      - "3888:3888"
+  kafka:
+    image: debezium/kafka:0.3
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      ZOOKEEPER_CONNECT: zookeeper:2181
+  connect: 
+    image: debezium/connect:0.3
+    container_name: connect
+    environment: 
+      BOOTSTRAP_SERVERS: kafka:9092
+      GROUP_ID: 1
+      CONFIG_STORAGE_TOPIC: my_connect_configs
+      OFFSET_STORAGE_TOPIC: my_connect_offsets
+    ports: 
+      - "8083:8083"
+  mysql:
+    image: debezium/example-mysql:0.3
+    container_name: mysql
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: debezium
+      MYSQL_USER: mysqluser
+      MYSQL_PASSWORD: mysqlpw


### PR DESCRIPTION
Some comments around this that would get factored into the tutorial:

To run from the same folder containing the docker-compose.yml file: `docker-compose up -d`
Then running `docker-compose ps`, you should see:

```
     Name                   Command             State                                   Ports                                  
------------------------------------------------------------------------------------------------------------------------------
connect           /docker-entrypoint.sh start   Up      0.0.0.0:8083->8083/tcp, 9092/tcp                                       
kafka             /docker-entrypoint.sh start   Up      0.0.0.0:9092->9092/tcp                                                 
mysql             docker-entrypoint.sh mysqld   Up      0.0.0.0:3306->3306/tcp                                                 
zookeeper         /docker-entrypoint.sh start   Up      0.0.0.0:2181->2181/tcp, 0.0.0.0:2888->2888/tcp, 0.0.0.0:3888->3888/tcp 
```

Since this is a version 2.0 docker-compose.yml, it will automatically generate a network for the containers spawned and they can reference eachother by their container names.

Running `docker network ls` shows you something like this:

```
NETWORK ID          NAME                DRIVER              SCOPE
8d5b42dcea40        03_default          bridge              local 
```

The tutorial uses various disposable containers to run up a mysql terminal and to create a kafka topic as well as a 'watcher' for the 'dbserver1.inventory.customers' topic.  These will need to reference the network above in order to be able to communicate with the existing containers, hence the `--net 03_default` references below.

`docker run -it --rm --name mysqlterm --net 03_default --rm mysql:5.7 sh -c 'exec mysql -h "mysql" -P "3306" -umysqluser -pmysqlpw'`

`docker run -it --rm --net 03_default -e ZOOKEEPER_CONNECT=zookeeper:2181 debezium/kafka:0.3 create-topic -r 1 dbhistory.inventory`

`docker run -it --name watcher --rm --net 03_default -e ZOOKEEPER_CONNECT=zookeeper:2181 debezium/kafka:0.3 watch-topic -a -k dbserver1.inventory.customers`

In the part of the tutorial related to stopping/restarting (recreating) the 'connect' container, in this instance, we could run `docker-compose stop connect` .... then apply those changes to the mysql database ... and then run `docker-compose start connect`.

To stop all running containers, run `docker-compose stop` and then remove them with, `docker-compose rm`.  It will prompt you if you wish to remove all the named containers.
