### PR TITLE
DBZ-3 Updates the PG server configuration to allow more WAL sender processes and replication slots

### DIFF
--- a/postgres/9.6/Dockerfile
+++ b/postgres/9.6/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*             
  
 # Compile the plugin from sources and install it
-RUN git clone https://github.com/debezium/postgres-decoderbufs -b v0.2.0 --single-branch \
+RUN git clone https://github.com/debezium/postgres-decoderbufs -b v0.3.0 --single-branch \
     && cd /postgres-decoderbufs \ 
     && make && make install \
     && cd / \ 

--- a/postgres/9.6/postgresql.conf.sample
+++ b/postgres/9.6/postgresql.conf.sample
@@ -1,5 +1,6 @@
 # LOGGING
-log_min_error_statement = fatal
+# log_min_error_statement = fatal
+# log_min_messages = DEBUG1
 
 # CONNECTION
 listen_addresses = '*'
@@ -9,7 +10,7 @@ shared_preload_libraries = 'decoderbufs'
 
 # REPLICATION
 wal_level = logical             # minimal, archive, hot_standby, or logical (change requires restart)
-max_wal_senders = 1             # max number of walsender processes (change requires restart)
+max_wal_senders = 4             # max number of walsender processes (change requires restart)
 #wal_keep_segments = 4          # in logfile segments, 16MB each; 0 disables
 #wal_sender_timeout = 60s       # in milliseconds; 0 disables
-max_replication_slots = 1       # max number of replication slots (change requires restart)
+max_replication_slots = 4       # max number of replication slots (change requires restart)


### PR DESCRIPTION
It also updates the Docker image to use tag `0.3.0` of the plugin