### PR TITLE
DBZ-939 Replace deprecated base image by java-centos-openjdk8-jdk

### DIFF
--- a/kafka/0.9/Dockerfile
+++ b/kafka/0.9/Dockerfile
@@ -1,4 +1,4 @@
-FROM fabric8/java-jboss-openjdk8-jdk
+FROM fabric8/java-centos-openjdk8-jdk
 
 MAINTAINER Debezium Community
 

--- a/zookeeper/0.9/Dockerfile
+++ b/zookeeper/0.9/Dockerfile
@@ -1,4 +1,4 @@
-FROM fabric8/java-jboss-openjdk8-jdk
+FROM fabric8/java-centos-openjdk8-jdk
 
 MAINTAINER Debezium Community
 


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-939

Base image for Docker images is currently "fabric8/java-jboss-openjdk8-jdk", which is marked as deprecated (cf https://hub.docker.com/r/fabric8/java-jboss-openjdk8-jdk/ or https://github.com/fabric8io-images/java/pull/24).