### PR TITLE
DBZ-1148 Using Kafkacat 1.4.0-RC1

### DIFF
--- a/tooling/Dockerfile
+++ b/tooling/Dockerfile
@@ -1,8 +1,7 @@
 FROM fedora:28
-RUN dnf -y install gcc which gcc-c++ wget make
-RUN mkdir kafkacat &&\
-    curl -L https://github.com/edenhill/kafkacat/archive/1.3.1.tar.gz | tar xz --strip-components 1 -C kafkacat &&\
-    cd kafkacat &&\
+RUN dnf -y install gcc which gcc-c++ wget make git
+RUN git clone https://github.com/edenhill/kafkacat -b 1.4.0-RC1 --single-branch && \
+    cd kafkacat && \
     ./bootstrap.sh
 
 FROM fedora:28

--- a/tooling/Dockerfile
+++ b/tooling/Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:28
-RUN dnf -y install gcc which gcc-c++ wget make git
+RUN dnf -y install gcc which gcc-c++ wget make git cmake
 RUN git clone https://github.com/edenhill/kafkacat -b 1.4.0-RC1 --single-branch && \
     cd kafkacat && \
     ./bootstrap.sh


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-1148

@jpechane, I noticed that building kafkacat from source isn't 100% reproduceable despite building a specific tag/version: the bootstrap.sh script obtains some dependencies (librdkafka) by getting their source from their master branch.

Can you tag a version of the _debezium/tooling_ image, e.g. 0.1, so we have a stable, referenceable version of it? Thanks!