### PR TITLE
DBZ-317 Include Antora in the awestruct docker image

### DIFF
--- a/awestruct/Dockerfile
+++ b/awestruct/Dockerfile
@@ -4,7 +4,29 @@ MAINTAINER Debezium Community http://debezium.io
  
 ENV SITE_HOME=/site \
     CACHE_HOME=/cache \
-    HOME=/home/awestruct
+    HOME=/home/awestruct \
+    NODE_PATH=/usr/local/share/.config/yarn/global/node_modules
+
+# Install Node.js - Required by Antora
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+    && apt-get install -y nodejs
+
+# Install Yarn
+RUN npm install -g yarn
+
+# Install Antora framework
+RUN yarn global add @antora/cli@latest @antora/site-generator-default@latest \
+    && rm -rf $(yarn cache dir)/* \
+    && find $(yarn global dir)/node_modules/asciidoctor.js/dist/* -maxdepth 0 -not -name node -exec rm -rf {} \; \
+    && find $(yarn global dir)/node_modules/handlebars/dist/* -maxdepth 0 -not -name cjs -exec rm -rf {} \; \
+    && find $(yarn global dir)/node_modules/handlebars/lib/* -maxdepth 0 -not -name index.js -exec rm -rf {} \; \
+    && find $(yarn global dir)/node_modules/isomorphic-git/dist/* -maxdepth 0 -not -name for-node -exec rm -rf {} \; \
+    && rm -rf $(yarn global dir)/node_modules/moment/min \
+    && rm -rf $(yarn global dir)/node_modules/moment/src \
+    && apt-get install -y jq \
+    && rm -rf /tmp/*
+
+RUN apt-get install git
 
 # Set up a user to run Awestruct and own all of its files (including the gems)
 RUN useradd -m awestruct && \


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-317

This PR simply makes sure that the _Antora_ framework is included as part of the website Awestruct docker image that builds our website.  We'll need to make sure this image is pulled down by everyone and any automated build process to guarantee that _Antora_ is available.