### PR TITLE
Revert "DBZ-1719 Upgrading to Ruby 2.4 as that's needed by Awestruct 0.6.0"

### DIFF
--- a/awestruct/Dockerfile
+++ b/awestruct/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4
+FROM ruby:2.3
  
 LABEL maintainer="Debezium Community"
  


### PR DESCRIPTION
Reverts debezium/docker-images#159