### PR TITLE
Ability to explicitly specify replica hostname for Mongo example image

### DIFF
--- a/examples/mongodb/1.2/init-inventory.sh
+++ b/examples/mongodb/1.2/init-inventory.sh
@@ -1,5 +1,20 @@
 HOSTNAME=`hostname`
 
+  OPTS=`getopt -o h: --long hostname: -n 'parse-options' -- "$@"`
+  if [ $? != 0 ] ; then echo "Failed parsing options." >&2 ; exit 1 ; fi
+
+  echo "$OPTS"
+  eval set -- "$OPTS"
+
+  while true; do
+    case "$1" in
+      -h | --hostname )     HOSTNAME=$2;        shift; shift ;;
+      -- ) shift; break ;;
+      * ) break ;;
+    esac
+  done
+echo "Using HOSTNAME='$HOSTNAME'"
+
 mongo localhost:27017/inventory <<-EOF
     rs.initiate({
         _id: "rs0",


### PR DESCRIPTION
Backwards compatible. Adds ability to specify replica hostname as
```/usr/local/bin/init-inventory.sh -h mongo.debezium-mongo.svc.cluster.local```

or 

```/usr/local/bin/init-inventory.sh --hostname mongo.debezium-mongo.svc.cluster.local```

This is especially useful in OCP where ```hostname``` resolves to pod hostname, however the service name is required in order for the replica to work correctly. 