### PR TITLE
DBZ-2083 add Apicurio converters

### DIFF
--- a/connect-base/1.2/Dockerfile
+++ b/connect-base/1.2/Dockerfile
@@ -13,13 +13,15 @@ COPY docker-maven-download.sh /usr/local/bin/docker-maven-download
 # Set up the plugins directory ...
 #
 ENV KAFKA_CONNECT_PLUGINS_DIR=$KAFKA_HOME/connect \
+    EXTERNAL_LIBS_DIR=$KAFKA_HOME/external_libs \
     CONNECT_PLUGIN_PATH=$KAFKA_CONNECT_PLUGINS_DIR \
     MAVEN_DEP_DESTINATION=$KAFKA_HOME/libs \
     CONFLUENT_VERSION=5.5.0 \
     AVRO_VERSION=1.9.2 \
-    AVRO_JACKSON_VERSION=1.9.13
+    AVRO_JACKSON_VERSION=1.9.13 \
+    APICURIO_VERSION=1.2.2.Final
 
-RUN mkdir $KAFKA_CONNECT_PLUGINS_DIR;
+RUN mkdir "$KAFKA_CONNECT_PLUGINS_DIR" "$EXTERNAL_LIBS_DIR"
 
 #
 # The `docker-entrypoint.sh` script will automatically discover the child directories
@@ -43,7 +45,8 @@ RUN docker-maven-download confluent kafka-connect-avro-converter "$CONFLUENT_VER
     docker-maven-download confluent common-utils "$CONFLUENT_VERSION" ad9e39d87c6a9fa1a9b19e6ce80392fa && \
     docker-maven-download central org/codehaus/jackson jackson-core-asl "$AVRO_JACKSON_VERSION" 319c49a4304e3fa9fe3cd8dcfc009d37 && \
     docker-maven-download central org/codehaus/jackson jackson-mapper-asl "$AVRO_JACKSON_VERSION" 1750f9c339352fc4b728d61b57171613 && \
-    docker-maven-download central org/apache/avro avro "$AVRO_VERSION" cb70195f70f52b27070f9359b77690bb
+    docker-maven-download central org/apache/avro avro "$AVRO_VERSION" cb70195f70f52b27070f9359b77690bb && \
+    docker-maven-download apicurio "$APICURIO_VERSION" 2a872aa67d1e2264d4bb87d1cfaba7f2
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["start"]

--- a/connect-base/1.2/README.md
+++ b/connect-base/1.2/README.md
@@ -115,6 +115,11 @@ This environment variable is recommended. Use this to set the JVM options for th
 
 This environment variable is optional. Use this to set the level of detail for Kafka's application log written to STDOUT and STDERR. Valid values are `INFO` (default), `WARN`, `ERROR`, `DEBUG`, or `TRACE`."
 
+### `DEBEZIUM_ENABLE_APICURIO`
+
+This environment variable is optional. Use this to enable [Apicur.io](https://www.apicur.io/) converters with 
+Apicurio Schema Registry by setting `DEBEZIUM_ENABLE_APICURIO=true` as container env var. Valid values are `false` to disable (default) or `true` to enable Apicurio converters.
+
 ### Others
 
 Environment variables that start with `CONNECT_` will be used to update the Kafka Connect worker configuration file. Each environment variable name will be mapped to a configuration property name by:

--- a/connect-base/1.2/docker-entrypoint.sh
+++ b/connect-base/1.2/docker-entrypoint.sh
@@ -29,6 +29,7 @@ fi
 : ${VALUE_CONVERTER:=org.apache.kafka.connect.json.JsonConverter}
 : ${INTERNAL_KEY_CONVERTER:=org.apache.kafka.connect.json.JsonConverter}
 : ${INTERNAL_VALUE_CONVERTER:=org.apache.kafka.connect.json.JsonConverter}
+: ${DEBEZIUM_ENABLE_APICURIO:=0}
 export CONNECT_REST_ADVERTISED_PORT=$ADVERTISED_PORT
 export CONNECT_REST_ADVERTISED_HOST_NAME=$ADVERTISED_HOST_NAME
 export CONNECT_REST_PORT=$REST_PORT
@@ -74,6 +75,21 @@ if [ -z "$CONNECT_PLUGIN_PATH" ]; then
     CONNECT_PLUGIN_PATH=$KAFKA_CONNECT_PLUGINS_DIR
 fi
 echo "Plugins are loaded from $CONNECT_PLUGIN_PATH"
+
+if [[ "${DEBEZIUM_ENABLE_APICURIO}" == "true" && ! -z "$EXTERNAL_LIBS_DIR" && -d "$EXTERNAL_LIBS_DIR/apicurio" ]] ; then
+    plugin_dirs=(${CONNECT_PLUGIN_PATH//,/ })
+    for plugin_dir in $plugin_dirs ; do
+        for connector in $plugin_dir/*/ ; do
+            ln -snf $KAFKA_HOME/external_libs/apicurio/* "$connector"
+        done
+    done
+    echo "Apicurio connectors enabled!"
+else
+    plugin_dirs=(${CONNECT_PLUGIN_PATH//,/ })
+    for plugin_dir in $plugin_dirs ; do
+        find $plugin_dir/ -lname "$KAFKA_HOME/external_libs/apicurio/*" -exec rm -f {} \;
+    done
+fi
 
 #
 # Set up the JMX options

--- a/connect-base/1.2/docker-maven-download.sh
+++ b/connect-base/1.2/docker-maven-download.sh
@@ -18,6 +18,7 @@ MAVEN_REPO_CENTRAL=${MAVEN_REPO_CENTRAL:-"https://repo1.maven.org/maven2"}
 MAVEN_REPO_INCUBATOR=${MAVEN_REPO_INCUBATOR:-"https://repo1.maven.org/maven2"}
 MAVEN_REPO_CONFLUENT=${MAVEN_REPO_CONFLUENT:-"https://packages.confluent.io/maven"}
 MAVEN_DEP_DESTINATION=${MAVEN_DEP_DESTINATION}
+EXTERNAL_LIBS_DIR=${EXTERNAL_LIBS_DIR}
 
 maven_dep() {
     local REPO="$1"
@@ -56,6 +57,21 @@ maven_debezium_incubator_plugin() {
     tar -xzf "$DOWNLOAD_FILE" -C "$MAVEN_DEP_DESTINATION" && rm "$DOWNLOAD_FILE"
 }
 
+maven_apicurio_converter() {
+    if [[ -z "$EXTERNAL_LIBS_DIR" ]] ; then
+        echo "WARNING: EXTERNAL_LIBS_DIR is not set. Skipping Apicurio converter loading..."
+        return
+    fi
+    if [[ ! -d "$EXTERNAL_LIBS_DIR" ]] ; then
+        echo "WARNING: EXTERNAL_LIBS_DIR is not a directory. Skipping Apicurio converter loading..."
+        return
+    fi
+    APICURIO_CONVERTER_PACKAGE="apicurio-registry-distro-connect-converter"
+    maven_dep $MAVEN_REPO_CENTRAL "io/apicurio" "$APICURIO_CONVERTER_PACKAGE" "$1" "$APICURIO_CONVERTER_PACKAGE-$1-converter.tar.gz" "$2"
+    mkdir "$EXTERNAL_LIBS_DIR/apicurio"
+    tar -xzf "$DOWNLOAD_FILE" -C "$EXTERNAL_LIBS_DIR/apicurio" && rm "$DOWNLOAD_FILE"
+}
+
 case $1 in
     "central" ) shift
             maven_central_dep ${@}
@@ -68,5 +84,8 @@ case $1 in
             ;;
     "debezium-incubator" ) shift
             maven_debezium_incubator_plugin ${@}
+            ;;
+    "apicurio" ) shift
+            maven_apicurio_converter ${@}
             ;;
 esac

--- a/connect-base/1.3/Dockerfile
+++ b/connect-base/1.3/Dockerfile
@@ -13,13 +13,15 @@ COPY docker-maven-download.sh /usr/local/bin/docker-maven-download
 # Set up the plugins directory ...
 #
 ENV KAFKA_CONNECT_PLUGINS_DIR=$KAFKA_HOME/connect \
+    EXTERNAL_LIBS_DIR=$KAFKA_HOME/external_libs \
     CONNECT_PLUGIN_PATH=$KAFKA_CONNECT_PLUGINS_DIR \
     MAVEN_DEP_DESTINATION=$KAFKA_HOME/libs \
     CONFLUENT_VERSION=5.5.0 \
     AVRO_VERSION=1.9.2 \
-    AVRO_JACKSON_VERSION=1.9.13
+    AVRO_JACKSON_VERSION=1.9.13 \
+    APICURIO_VERSION=1.2.2.Final
 
-RUN mkdir $KAFKA_CONNECT_PLUGINS_DIR;
+RUN mkdir "$KAFKA_CONNECT_PLUGINS_DIR" "$EXTERNAL_LIBS_DIR"
 
 #
 # The `docker-entrypoint.sh` script will automatically discover the child directories
@@ -43,7 +45,8 @@ RUN docker-maven-download confluent kafka-connect-avro-converter "$CONFLUENT_VER
     docker-maven-download confluent common-utils "$CONFLUENT_VERSION" ad9e39d87c6a9fa1a9b19e6ce80392fa && \
     docker-maven-download central org/codehaus/jackson jackson-core-asl "$AVRO_JACKSON_VERSION" 319c49a4304e3fa9fe3cd8dcfc009d37 && \
     docker-maven-download central org/codehaus/jackson jackson-mapper-asl "$AVRO_JACKSON_VERSION" 1750f9c339352fc4b728d61b57171613 && \
-    docker-maven-download central org/apache/avro avro "$AVRO_VERSION" cb70195f70f52b27070f9359b77690bb
+    docker-maven-download central org/apache/avro avro "$AVRO_VERSION" cb70195f70f52b27070f9359b77690bb && \
+    docker-maven-download apicurio "$APICURIO_VERSION" 2a872aa67d1e2264d4bb87d1cfaba7f2
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["start"]

--- a/connect-base/1.3/README.md
+++ b/connect-base/1.3/README.md
@@ -115,6 +115,11 @@ This environment variable is recommended. Use this to set the JVM options for th
 
 This environment variable is optional. Use this to set the level of detail for Kafka's application log written to STDOUT and STDERR. Valid values are `INFO` (default), `WARN`, `ERROR`, `DEBUG`, or `TRACE`."
 
+### `DEBEZIUM_ENABLE_APICURIO`
+
+This environment variable is optional. Use this to enable [Apicur.io](https://www.apicur.io/) converters with 
+Apicurio Schema Registry by setting `DEBEZIUM_ENABLE_APICURIO=true` as container env var. Valid values are `false` to disable (default) or `true` to enable Apicurio converters.
+
 ### Others
 
 Environment variables that start with `CONNECT_` will be used to update the Kafka Connect worker configuration file. Each environment variable name will be mapped to a configuration property name by:

--- a/connect-base/1.3/docker-entrypoint.sh
+++ b/connect-base/1.3/docker-entrypoint.sh
@@ -29,6 +29,7 @@ fi
 : ${VALUE_CONVERTER:=org.apache.kafka.connect.json.JsonConverter}
 : ${INTERNAL_KEY_CONVERTER:=org.apache.kafka.connect.json.JsonConverter}
 : ${INTERNAL_VALUE_CONVERTER:=org.apache.kafka.connect.json.JsonConverter}
+: ${DEBEZIUM_ENABLE_APICURIO:=0}
 export CONNECT_REST_ADVERTISED_PORT=$ADVERTISED_PORT
 export CONNECT_REST_ADVERTISED_HOST_NAME=$ADVERTISED_HOST_NAME
 export CONNECT_REST_PORT=$REST_PORT
@@ -74,6 +75,21 @@ if [ -z "$CONNECT_PLUGIN_PATH" ]; then
     CONNECT_PLUGIN_PATH=$KAFKA_CONNECT_PLUGINS_DIR
 fi
 echo "Plugins are loaded from $CONNECT_PLUGIN_PATH"
+
+if [[ "${DEBEZIUM_ENABLE_APICURIO}" == "true" && ! -z "$EXTERNAL_LIBS_DIR" && -d "$EXTERNAL_LIBS_DIR/apicurio" ]] ; then
+    plugin_dirs=(${CONNECT_PLUGIN_PATH//,/ })
+    for plugin_dir in $plugin_dirs ; do
+        for connector in $plugin_dir/*/ ; do
+            ln -snf $KAFKA_HOME/external_libs/apicurio/* "$connector"
+        done
+    done
+    echo "Apicurio connectors enabled!"
+else
+    plugin_dirs=(${CONNECT_PLUGIN_PATH//,/ })
+    for plugin_dir in $plugin_dirs ; do
+        find $plugin_dir/ -lname "$KAFKA_HOME/external_libs/apicurio/*" -exec rm -f {} \;
+    done
+fi
 
 #
 # Set up the JMX options

--- a/connect-base/1.3/docker-maven-download.sh
+++ b/connect-base/1.3/docker-maven-download.sh
@@ -18,6 +18,7 @@ MAVEN_REPO_CENTRAL=${MAVEN_REPO_CENTRAL:-"https://repo1.maven.org/maven2"}
 MAVEN_REPO_INCUBATOR=${MAVEN_REPO_INCUBATOR:-"https://repo1.maven.org/maven2"}
 MAVEN_REPO_CONFLUENT=${MAVEN_REPO_CONFLUENT:-"https://packages.confluent.io/maven"}
 MAVEN_DEP_DESTINATION=${MAVEN_DEP_DESTINATION}
+EXTERNAL_LIBS_DIR=${EXTERNAL_LIBS_DIR}
 
 maven_dep() {
     local REPO="$1"
@@ -56,6 +57,21 @@ maven_debezium_incubator_plugin() {
     tar -xzf "$DOWNLOAD_FILE" -C "$MAVEN_DEP_DESTINATION" && rm "$DOWNLOAD_FILE"
 }
 
+maven_apicurio_converter() {
+    if [[ -z "$EXTERNAL_LIBS_DIR" ]] ; then
+        echo "WARNING: EXTERNAL_LIBS_DIR is not set. Skipping Apicurio converter loading..."
+        return
+    fi
+    if [[ ! -d "$EXTERNAL_LIBS_DIR" ]] ; then
+        echo "WARNING: EXTERNAL_LIBS_DIR is not a directory. Skipping Apicurio converter loading..."
+        return
+    fi
+    APICURIO_CONVERTER_PACKAGE="apicurio-registry-distro-connect-converter"
+    maven_dep $MAVEN_REPO_CENTRAL "io/apicurio" "$APICURIO_CONVERTER_PACKAGE" "$1" "$APICURIO_CONVERTER_PACKAGE-$1-converter.tar.gz" "$2"
+    mkdir "$EXTERNAL_LIBS_DIR/apicurio"
+    tar -xzf "$DOWNLOAD_FILE" -C "$EXTERNAL_LIBS_DIR/apicurio" && rm "$DOWNLOAD_FILE"
+}
+
 case $1 in
     "central" ) shift
             maven_central_dep ${@}
@@ -68,5 +84,8 @@ case $1 in
             ;;
     "debezium-incubator" ) shift
             maven_debezium_incubator_plugin ${@}
+            ;;
+    "apicurio" ) shift
+            maven_apicurio_converter ${@}
             ;;
 esac

--- a/connect/1.2/README.md
+++ b/connect/1.2/README.md
@@ -104,6 +104,11 @@ This environment variable is recommended. Use this to set the JVM options for th
 
 This environment variable is optional. Use this to set the level of detail for Kafka's application log written to STDOUT and STDERR. Valid values are `INFO` (default), `WARN`, `ERROR`, `DEBUG`, or `TRACE`."
 
+### `DEBEZIUM_ENABLE_APICURIO`
+
+This environment variable is optional. Use this to enable [Apicur.io](https://www.apicur.io/) converters with 
+Apicurio Schema Registry by setting `DEBEZIUM_ENABLE_APICURIO=true` as container env var. Valid values are `false` to disable (default) or `true` to enable Apicurio converters.
+
 ### Others
 
 Environment variables that start with `CONNECT_` will be used to update the Kafka Connect worker configuration file. Each environment variable name will be mapped to a configuration property name by:

--- a/connect/1.3/README.md
+++ b/connect/1.3/README.md
@@ -104,6 +104,11 @@ This environment variable is recommended. Use this to set the JVM options for th
 
 This environment variable is optional. Use this to set the level of detail for Kafka's application log written to STDOUT and STDERR. Valid values are `INFO` (default), `WARN`, `ERROR`, `DEBUG`, or `TRACE`."
 
+### `DEBEZIUM_ENABLE_APICURIO`
+
+This environment variable is optional. Use this to enable [Apicur.io](https://www.apicur.io/) converters with 
+Apicurio Schema Registry by setting `DEBEZIUM_ENABLE_APICURIO=true` as container env var. Valid values are `false` to disable (default) or `true` to enable Apicurio converters.
+
 ### Others
 
 Environment variables that start with `CONNECT_` will be used to update the Kafka Connect worker configuration file. Each environment variable name will be mapped to a configuration property name by:


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-2083

I added an optional env var `DEBEZIUM_ENABLE_APICURIO`.
When it's set to `DEBEZIUM_ENABLE_APICURIO=1` it'll symlink Apicurio distro JARs to debezium converters in `$KAFKA_CONNECT_PLUGINS_DIR` (/kafka/connect/).

I added this to images version 1.2 and 1.3
