### PR TITLE
DBZ-2083 rename env var to enable Apicurio converters

### DIFF
--- a/connect-base/1.2/README.md
+++ b/connect-base/1.2/README.md
@@ -115,10 +115,10 @@ This environment variable is recommended. Use this to set the JVM options for th
 
 This environment variable is optional. Use this to set the level of detail for Kafka's application log written to STDOUT and STDERR. Valid values are `INFO` (default), `WARN`, `ERROR`, `DEBUG`, or `TRACE`."
 
-### `DEBEZIUM_ENABLE_APICURIO`
+### `ENABLE_APICURIO_CONVERTERS`
 
 This environment variable is optional. Use this to enable [Apicur.io](https://www.apicur.io/) converters with 
-Apicurio Schema Registry by setting `DEBEZIUM_ENABLE_APICURIO=true` as container env var. Valid values are `false` to disable (default) or `true` to enable Apicurio converters.
+Apicurio Schema Registry by setting `ENABLE_APICURIO_CONVERTERS=true` as container env var. Valid values are `false` to disable (default) or `true` to enable Apicurio converters.
 
 ### Others
 

--- a/connect-base/1.2/docker-entrypoint.sh
+++ b/connect-base/1.2/docker-entrypoint.sh
@@ -29,7 +29,7 @@ fi
 : ${VALUE_CONVERTER:=org.apache.kafka.connect.json.JsonConverter}
 : ${INTERNAL_KEY_CONVERTER:=org.apache.kafka.connect.json.JsonConverter}
 : ${INTERNAL_VALUE_CONVERTER:=org.apache.kafka.connect.json.JsonConverter}
-: ${DEBEZIUM_ENABLE_APICURIO:=0}
+: ${ENABLE_APICURIO_CONVERTERS:=false}
 export CONNECT_REST_ADVERTISED_PORT=$ADVERTISED_PORT
 export CONNECT_REST_ADVERTISED_HOST_NAME=$ADVERTISED_HOST_NAME
 export CONNECT_REST_PORT=$REST_PORT
@@ -76,7 +76,7 @@ if [ -z "$CONNECT_PLUGIN_PATH" ]; then
 fi
 echo "Plugins are loaded from $CONNECT_PLUGIN_PATH"
 
-if [[ "${DEBEZIUM_ENABLE_APICURIO}" == "true" && ! -z "$EXTERNAL_LIBS_DIR" && -d "$EXTERNAL_LIBS_DIR/apicurio" ]] ; then
+if [[ "${ENABLE_APICURIO_CONVERTERS}" == "true" && ! -z "$EXTERNAL_LIBS_DIR" && -d "$EXTERNAL_LIBS_DIR/apicurio" ]] ; then
     plugin_dirs=(${CONNECT_PLUGIN_PATH//,/ })
     for plugin_dir in $plugin_dirs ; do
         for connector in $plugin_dir/*/ ; do

--- a/connect-base/1.3/README.md
+++ b/connect-base/1.3/README.md
@@ -115,10 +115,10 @@ This environment variable is recommended. Use this to set the JVM options for th
 
 This environment variable is optional. Use this to set the level of detail for Kafka's application log written to STDOUT and STDERR. Valid values are `INFO` (default), `WARN`, `ERROR`, `DEBUG`, or `TRACE`."
 
-### `DEBEZIUM_ENABLE_APICURIO`
+### `ENABLE_APICURIO_CONVERTERS`
 
 This environment variable is optional. Use this to enable [Apicur.io](https://www.apicur.io/) converters with 
-Apicurio Schema Registry by setting `DEBEZIUM_ENABLE_APICURIO=true` as container env var. Valid values are `false` to disable (default) or `true` to enable Apicurio converters.
+Apicurio Schema Registry by setting `ENABLE_APICURIO_CONVERTERS=true` as container env var. Valid values are `false` to disable (default) or `true` to enable Apicurio converters.
 
 ### Others
 

--- a/connect-base/1.3/docker-entrypoint.sh
+++ b/connect-base/1.3/docker-entrypoint.sh
@@ -29,7 +29,7 @@ fi
 : ${VALUE_CONVERTER:=org.apache.kafka.connect.json.JsonConverter}
 : ${INTERNAL_KEY_CONVERTER:=org.apache.kafka.connect.json.JsonConverter}
 : ${INTERNAL_VALUE_CONVERTER:=org.apache.kafka.connect.json.JsonConverter}
-: ${DEBEZIUM_ENABLE_APICURIO:=0}
+: ${ENABLE_APICURIO_CONVERTERS:=false}
 export CONNECT_REST_ADVERTISED_PORT=$ADVERTISED_PORT
 export CONNECT_REST_ADVERTISED_HOST_NAME=$ADVERTISED_HOST_NAME
 export CONNECT_REST_PORT=$REST_PORT
@@ -76,7 +76,7 @@ if [ -z "$CONNECT_PLUGIN_PATH" ]; then
 fi
 echo "Plugins are loaded from $CONNECT_PLUGIN_PATH"
 
-if [[ "${DEBEZIUM_ENABLE_APICURIO}" == "true" && ! -z "$EXTERNAL_LIBS_DIR" && -d "$EXTERNAL_LIBS_DIR/apicurio" ]] ; then
+if [[ "${ENABLE_APICURIO_CONVERTERS}" == "true" && ! -z "$EXTERNAL_LIBS_DIR" && -d "$EXTERNAL_LIBS_DIR/apicurio" ]] ; then
     plugin_dirs=(${CONNECT_PLUGIN_PATH//,/ })
     for plugin_dir in $plugin_dirs ; do
         for connector in $plugin_dir/*/ ; do

--- a/connect/1.2/README.md
+++ b/connect/1.2/README.md
@@ -104,10 +104,10 @@ This environment variable is recommended. Use this to set the JVM options for th
 
 This environment variable is optional. Use this to set the level of detail for Kafka's application log written to STDOUT and STDERR. Valid values are `INFO` (default), `WARN`, `ERROR`, `DEBUG`, or `TRACE`."
 
-### `DEBEZIUM_ENABLE_APICURIO`
+### `ENABLE_APICURIO_CONVERTERS`
 
 This environment variable is optional. Use this to enable [Apicur.io](https://www.apicur.io/) converters with 
-Apicurio Schema Registry by setting `DEBEZIUM_ENABLE_APICURIO=true` as container env var. Valid values are `false` to disable (default) or `true` to enable Apicurio converters.
+Apicurio Schema Registry by setting `ENABLE_APICURIO_CONVERTERS=true` as container env var. Valid values are `false` to disable (default) or `true` to enable Apicurio converters.
 
 ### Others
 

--- a/connect/1.3/README.md
+++ b/connect/1.3/README.md
@@ -104,10 +104,10 @@ This environment variable is recommended. Use this to set the JVM options for th
 
 This environment variable is optional. Use this to set the level of detail for Kafka's application log written to STDOUT and STDERR. Valid values are `INFO` (default), `WARN`, `ERROR`, `DEBUG`, or `TRACE`."
 
-### `DEBEZIUM_ENABLE_APICURIO`
+### `ENABLE_APICURIO_CONVERTERS`
 
 This environment variable is optional. Use this to enable [Apicur.io](https://www.apicur.io/) converters with 
-Apicurio Schema Registry by setting `DEBEZIUM_ENABLE_APICURIO=true` as container env var. Valid values are `false` to disable (default) or `true` to enable Apicurio converters.
+Apicurio Schema Registry by setting `ENABLE_APICURIO_CONVERTERS=true` as container env var. Valid values are `false` to disable (default) or `true` to enable Apicurio converters.
 
 ### Others
 


### PR DESCRIPTION
Related to https://github.com/debezium/docker-images/pull/173#issuecomment-655889269 in #173 here's the renaming PR to rename the env var from `DEBEZIUM_ENABLE_APICURIO` to `ENABLE_APICURIO_CONVERTERS`
FYI @jpechane