### PR TITLE
Removing superfluous gems from website builder

### DIFF
--- a/website-builder/Dockerfile
+++ b/website-builder/Dockerfile
@@ -30,8 +30,6 @@ RUN apt-get install git
 # Install Rake and Bundler. This is the minimum needed to generate the site ...
 RUN gem install rdoc -v 6.2.0
 RUN gem install rake bundler
-RUN gem install bundler
-RUN gem install jekyll
  
 WORKDIR $SITE_HOME
 VOLUME [ $SITE_HOME ]


### PR DESCRIPTION
@uidoyen, I think jekyll is installed via bundler later on, so it's not needed here?