### PR TITLE
Potential fix for hypen-containing environment variables: DBZ-3019

### DIFF
--- a/connect-base/1.4/docker-entrypoint.sh
+++ b/connect-base/1.4/docker-entrypoint.sh
@@ -196,16 +196,17 @@ case $1 in
         do
           env_var=`echo "$VAR" | sed -r "s/(.*)=.*/\1/g"`
           prop_name=`echo "$VAR" | sed -r "s/^CONNECT_(.*)=.*/\1/g" | tr '[:upper:]' '[:lower:]' | tr _ .`
+          prop_value=`echo "$VAR" | sed -r "s/^CONNECT_.*=(.*)/\1/g"`
           if egrep -q "(^|^#)$prop_name=" $KAFKA_HOME/config/log4j.properties; then
               #note that no config names or values may contain an '@' char
-              sed -r -i "s@(^|^#)($prop_name)=(.*)@\2=${!env_var}@g" $KAFKA_HOME/config/log4j.properties
+              sed -r -i "s@(^|^#)($prop_name)=(.*)@\2=${prop_value}@g" $KAFKA_HOME/config/log4j.properties
           else
-              echo "$prop_name=${!env_var}" >> $KAFKA_HOME/config/log4j.properties
+              echo "$prop_name=${prop_value}" >> $KAFKA_HOME/config/log4j.properties
           fi
           if [[ "$SENSITIVE_PROPERTIES" = *"$env_var"* ]]; then
               echo "--- Setting logging property from $env_var: $prop_name=[hidden]"
           else
-              echo "--- Setting logging property from $env_var: $prop_name=${!env_var}"
+             echo "--- Setting logging property from $env_var: $prop_name=${prop_value}"
           fi
           unset $env_var
         done
@@ -223,17 +224,18 @@ case $1 in
           env_var=`echo "$VAR" | sed -r "s/(.*)=.*/\1/g"`
           if [[ $env_var =~ ^CONNECT ]]; then
             prop_name=`echo "$VAR" | sed -r "s/^CONNECT_(.*)=.*/\1/g" | tr '[:upper:]' '[:lower:]' | tr _ .`
+            prop_value=`echo "$VAR" | sed -r "s/^CONNECT_.*=(.*)/\1/g"`
             if egrep -q "(^|^#)$prop_name=" $KAFKA_HOME/config/connect-distributed.properties; then
                 #note that no config names or values may contain an '@' char
-                sed -r -i "s@(^|^#)($prop_name)=(.*)@\2=${!env_var}@g" $KAFKA_HOME/config/connect-distributed.properties
+                sed -r -i "s@(^|^#)($prop_name)=(.*)@\2=${prop_value}@g" $KAFKA_HOME/config/connect-distributed.properties
             else
-                #echo "Adding property $prop_name=${!env_var}"
-                echo "$prop_name=${!env_var}" >> $KAFKA_HOME/config/connect-distributed.properties
+                # echo "Adding property $prop_name=${prop_value}"
+                echo "$prop_name=${prop_value}" >> $KAFKA_HOME/config/connect-distributed.properties
             fi
             if [[ "$SENSITIVE_PROPERTIES" = *"$env_var"* ]]; then
                 echo "--- Setting property from $env_var: $prop_name=[hidden]"
             else
-                echo "--- Setting property from $env_var: $prop_name=${!env_var}"
+                echo "--- Setting property from $env_var: $prop_name=${prop_value}"
             fi
           fi
         done

--- a/connect-base/1.5/docker-entrypoint.sh
+++ b/connect-base/1.5/docker-entrypoint.sh
@@ -196,16 +196,17 @@ case $1 in
         do
           env_var=`echo "$VAR" | sed -r "s/(.*)=.*/\1/g"`
           prop_name=`echo "$VAR" | sed -r "s/^CONNECT_(.*)=.*/\1/g" | tr '[:upper:]' '[:lower:]' | tr _ .`
+          prop_value=`echo "$VAR" | sed -r "s/^CONNECT_.*=(.*)/\1/g"`
           if egrep -q "(^|^#)$prop_name=" $KAFKA_HOME/config/log4j.properties; then
               #note that no config names or values may contain an '@' char
-              sed -r -i "s@(^|^#)($prop_name)=(.*)@\2=${!env_var}@g" $KAFKA_HOME/config/log4j.properties
+              sed -r -i "s@(^|^#)($prop_name)=(.*)@\2=${prop_value}@g" $KAFKA_HOME/config/log4j.properties
           else
-              echo "$prop_name=${!env_var}" >> $KAFKA_HOME/config/log4j.properties
+              echo "$prop_name=${prop_value}" >> $KAFKA_HOME/config/log4j.properties
           fi
           if [[ "$SENSITIVE_PROPERTIES" = *"$env_var"* ]]; then
               echo "--- Setting logging property from $env_var: $prop_name=[hidden]"
           else
-              echo "--- Setting logging property from $env_var: $prop_name=${!env_var}"
+             echo "--- Setting logging property from $env_var: $prop_name=${prop_value}"
           fi
           unset $env_var
         done
@@ -223,17 +224,18 @@ case $1 in
           env_var=`echo "$VAR" | sed -r "s/(.*)=.*/\1/g"`
           if [[ $env_var =~ ^CONNECT ]]; then
             prop_name=`echo "$VAR" | sed -r "s/^CONNECT_(.*)=.*/\1/g" | tr '[:upper:]' '[:lower:]' | tr _ .`
+            prop_value=`echo "$VAR" | sed -r "s/^CONNECT_.*=(.*)/\1/g"`
             if egrep -q "(^|^#)$prop_name=" $KAFKA_HOME/config/connect-distributed.properties; then
                 #note that no config names or values may contain an '@' char
-                sed -r -i "s@(^|^#)($prop_name)=(.*)@\2=${!env_var}@g" $KAFKA_HOME/config/connect-distributed.properties
+                sed -r -i "s@(^|^#)($prop_name)=(.*)@\2=${prop_value}@g" $KAFKA_HOME/config/connect-distributed.properties
             else
-                #echo "Adding property $prop_name=${!env_var}"
-                echo "$prop_name=${!env_var}" >> $KAFKA_HOME/config/connect-distributed.properties
+                # echo "Adding property $prop_name=${prop_value}"
+                echo "$prop_name=${prop_value}" >> $KAFKA_HOME/config/connect-distributed.properties
             fi
             if [[ "$SENSITIVE_PROPERTIES" = *"$env_var"* ]]; then
                 echo "--- Setting property from $env_var: $prop_name=[hidden]"
             else
-                echo "--- Setting property from $env_var: $prop_name=${!env_var}"
+                echo "--- Setting property from $env_var: $prop_name=${prop_value}"
             fi
           fi
         done


### PR DESCRIPTION
Please refer to: https://issues.redhat.com/browse/DBZ-3019

As requested in the issue commentary, a change for this script.
 
I imagine a bash guru could optimize the value extraction of this code into a single line. 
I have changed the log4j creation code for completion, but this is likely unnecessary due to the constraints on package names.