### PR TITLE
DBZ-3326 Allow only JMX port setup

### DIFF
--- a/connect-base/1.4/docker-entrypoint.sh
+++ b/connect-base/1.4/docker-entrypoint.sh
@@ -120,7 +120,7 @@ fi
 #
 : ${JMXAUTH:="false"}
 : ${JMXSSL:="false"}
-if [[ -n "$JMXPORT" && -n "$JMXHOST" ]]; then
+if [[ -n "$JMXPORT"]]; then
     echo "Enabling JMX on ${JMXHOST}:${JMXPORT}"
     export KAFKA_JMX_OPTS="-Djava.rmi.server.hostname=${JMXHOST} -Dcom.sun.management.jmxremote.rmi.port=${JMXPORT} -Dcom.sun.management.jmxremote.port=${JMXPORT} -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=${JMXAUTH} -Dcom.sun.management.jmxremote.ssl=${JMXSSL} "
 fi


### PR DESCRIPTION
https://debezium.io/documentation/reference/operations/monitoring.html#kafka-connect-jmx-environment-variables-docker

And by why I found, forcing the host do not let me reach the jmx metrics outside of the docker-compose network AND as the same time acces it from an another docker in the compose.

if I set JMXHOST=localhost -> I can access outside of compose network
if I set JMXHOST=name_of_my_compose_service -> I can access it from another container in the compose network