### PR TITLE
DBZ-3903 Removing unnecessary VOLUME instruction

### DIFF
--- a/website-builder/Dockerfile
+++ b/website-builder/Dockerfile
@@ -32,7 +32,6 @@ ADD Gemfile.lock Gemfile.lock
 RUN bundle install 
 
 WORKDIR $SITE_HOME
-VOLUME $SITE_HOME
  
 EXPOSE 4000
  


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3903

@jpechane, this gave me trouble after some Docker upgrade, and I don't think it ever was needed anyways. How do we re-publish this image, is there a Jenkins job for it, too?