### PR TITLE
DBZ-3944 Fix for incorrect syntax in MySQL 8.0 example image💉

### DIFF
--- a/examples/mysql-gtids/1.7/Dockerfile
+++ b/examples/mysql-gtids/1.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5.7
+FROM mysql:8.0
 
 LABEL maintainer="Debezium Community"
 

--- a/examples/mysql-gtids/1.7/inventory.sql
+++ b/examples/mysql-gtids/1.7/inventory.sql
@@ -4,8 +4,10 @@
 # However, this grant is equivalent to specifying *any* hosts, which makes this easier since the docker host
 # is not easily known to the Docker container. But don't do this in production.
 #
-GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'replicator' IDENTIFIED BY 'replpass';
-GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT  ON *.* TO 'debezium' IDENTIFIED BY 'dbz';
+CREATE USER 'replicator' IDENTIFIED BY 'replpass';
+CREATE USER 'debezium' IDENTIFIED BY 'dbz';
+GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'replicator';
+GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT  ON *.* TO 'debezium';
 
 # Create the database that we'll use to populate data and watch the effect in the binlog
 CREATE DATABASE inventory;

--- a/examples/mysql-gtids/1.7/mysql.cnf
+++ b/examples/mysql-gtids/1.7/mysql.cnf
@@ -49,4 +49,4 @@ log_bin           = mysql-bin
 expire_logs_days  = 1
 binlog_format     = row
 
-
+default_authentication_plugin = mysql_native_password

--- a/examples/mysql/1.7/inventory.sql
+++ b/examples/mysql/1.7/inventory.sql
@@ -4,8 +4,10 @@
 # However, this grant is equivalent to specifying *any* hosts, which makes this easier since the docker host
 # is not easily known to the Docker container. But don't do this in production.
 #
-GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'replicator' IDENTIFIED BY 'replpass';
-GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT  ON *.* TO 'debezium' IDENTIFIED BY 'dbz';
+CREATE USER 'replicator' IDENTIFIED BY 'replpass';
+CREATE USER 'debezium' IDENTIFIED BY 'dbz';
+GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'replicator';
+GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT  ON *.* TO 'debezium';
 
 # Create the database that we'll use to populate data and watch the effect in the binlog
 CREATE DATABASE inventory;

--- a/examples/mysql/1.7/mysql.cnf
+++ b/examples/mysql/1.7/mysql.cnf
@@ -43,4 +43,4 @@ log_bin           = mysql-bin
 expire_logs_days  = 1
 binlog_format     = row
 
-
+default_authentication_plugin = mysql_native_password


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3944

Below 2 lines from `examples/mysql/1.7/inventory.sql` are non compliant with MySQL 8.0 syntax
```sql
GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'replicator' IDENTIFIED BY 'replpass';
GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT  ON *.* TO 'debezium' IDENTIFIED BY 'dbz';
```

this is because `GRANT` syntax in 8.0 no more accepts auth_options as it was in 5.7
```
auth_option: {
    IDENTIFIED BY 'auth_string'
  | IDENTIFIED WITH auth_plugin
  | IDENTIFIED WITH auth_plugin BY 'auth_string'
  | IDENTIFIED WITH auth_plugin AS 'auth_string'
  | IDENTIFIED BY PASSWORD 'auth_string'
}
```

This is now exclusive to `CREATE` statements only.
I see the image was recently updated. This prevents the image with defaults to start successfully.

References:
https://dev.mysql.com/doc/refman/5.7/en/grant.html
https://dev.mysql.com/doc/refman/8.0/en/grant.html