### PR TITLE
[release] Updating base image reference

### DIFF
--- a/connect-base/1.8/Dockerfile
+++ b/connect-base/1.8/Dockerfile
@@ -1,4 +1,4 @@
-FROM debezium/kafka:1.7
+FROM debezium/kafka:1.8
 
 LABEL maintainer="Debezium Community"
 

--- a/connect/1.8/Dockerfile
+++ b/connect/1.8/Dockerfile
@@ -1,4 +1,4 @@
-FROM debezium/connect-base:1.7
+FROM debezium/connect-base:1.8
 
 LABEL maintainer="Debezium Community"
 

--- a/connect/1.8/Dockerfile.local
+++ b/connect/1.8/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM debezium/connect-base:1.7
+FROM debezium/connect-base:1.8
 
 LABEL maintainer="Debezium Community"
 

--- a/connect/snapshot/Dockerfile
+++ b/connect/snapshot/Dockerfile
@@ -1,8 +1,8 @@
-FROM debezium/connect-base:1.7
+FROM debezium/connect-base:1.8
 
 LABEL maintainer="Debezium Community"
 
-ARG DEBEZIUM_VERSION=1.7.0-SNAPSHOT
+ARG DEBEZIUM_VERSION=1.8.0-SNAPSHOT
 
 ENV DEBEZIUM_VERSION=$DEBEZIUM_VERSION \
     MAVEN_OSS_SNAPSHOT="https://oss.sonatype.org/content/repositories/snapshots"


### PR DESCRIPTION
Hey @jpechane, trivial fix, but I'm wondering how this could happen. Aren't those versions pulled up automatically during the release or something?