### PR TITLE
Fix kafka connect property example documentation

### DIFF
--- a/connect/0.1/README.md
+++ b/connect/0.1/README.md
@@ -107,7 +107,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 

--- a/connect/0.10/README.md
+++ b/connect/0.10/README.md
@@ -112,7 +112,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 

--- a/connect/0.2/README.md
+++ b/connect/0.2/README.md
@@ -107,7 +107,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 

--- a/connect/0.3/README.md
+++ b/connect/0.3/README.md
@@ -107,7 +107,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 

--- a/connect/0.4/README.md
+++ b/connect/0.4/README.md
@@ -107,7 +107,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 

--- a/connect/0.5/README.md
+++ b/connect/0.5/README.md
@@ -107,7 +107,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 

--- a/connect/0.6/README.md
+++ b/connect/0.6/README.md
@@ -107,7 +107,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 

--- a/connect/0.7/README.md
+++ b/connect/0.7/README.md
@@ -111,7 +111,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 

--- a/connect/0.8/README.md
+++ b/connect/0.8/README.md
@@ -112,7 +112,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 

--- a/connect/0.9/README.md
+++ b/connect/0.9/README.md
@@ -112,7 +112,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 

--- a/connect/1.0/README.md
+++ b/connect/1.0/README.md
@@ -112,7 +112,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 

--- a/connect/1.1/README.md
+++ b/connect/1.1/README.md
@@ -112,7 +112,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 

--- a/connect/1.2/README.md
+++ b/connect/1.2/README.md
@@ -123,7 +123,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 

--- a/connect/1.3/README.md
+++ b/connect/1.3/README.md
@@ -124,7 +124,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 

--- a/connect/1.4/README.md
+++ b/connect/1.4/README.md
@@ -124,7 +124,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 

--- a/connect/1.5/README.md
+++ b/connect/1.5/README.md
@@ -124,7 +124,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 

--- a/connect/1.6/README.md
+++ b/connect/1.6/README.md
@@ -124,7 +124,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 

--- a/connect/1.7/README.md
+++ b/connect/1.7/README.md
@@ -124,7 +124,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 

--- a/connect/1.9/README.md
+++ b/connect/1.9/README.md
@@ -124,7 +124,7 @@ Environment variables that start with `CONNECT_` will be used to update the Kafk
 2. lowercasing all characters; and
 3. converting all '_' characters to '.' characters
 
-For example, the environment variable `CONNECT__HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
+For example, the environment variable `CONNECT_HEARTBEAT_INTERVAL_MS` is converted to the `heartbeat.interval.ms` property. The container will then update the Kafka Connect worker configuration file to include the property's name and value.
 
 The value of the environment variable may not contain a '\@' character.
 


### PR DESCRIPTION
changed the kafka connect environment variable pattern example.

This PR updates the docker image documentation to reflect these new expectation.