### PR TITLE
DBZ-4844 Remove --zookeeper flag from startup script

### DIFF
--- a/kafka/1.8/docker-entrypoint.sh
+++ b/kafka/1.8/docker-entrypoint.sh
@@ -164,7 +164,7 @@ case $1 in
                         config="--config=cleanup.policy=${topicConfig[3]}"
                     fi
                     echo "STARTUP: Creating topic ${topicConfig[0]} with ${topicConfig[1]} partitions and ${topicConfig[2]} replicas with cleanup policy ${topicConfig[3]}..."
-                    $KAFKA_HOME/bin/kafka-topics.sh --create --zookeeper $KAFKA_ZOOKEEPER_CONNECT --replication-factor ${topicConfig[2]} --partitions ${topicConfig[1]} --topic "${topicConfig[0]}" ${config}
+                    $KAFKA_HOME/bin/kafka-topics.sh --create --bootstrap-server $KAFKA_ZOOKEEPER_CONNECT --replication-factor ${topicConfig[2]} --partitions ${topicConfig[1]} --topic "${topicConfig[0]}" ${config}
                 done
             )&
         fi
@@ -271,11 +271,11 @@ case $1 in
         fi
         TOPICNAME=$1
         echo "Creating new topic $TOPICNAME with $PARTITION partition(s), $REPLICAS replica(s) and cleanup policy set to $CLEANUP_POLICY..."
-        exec $KAFKA_HOME/bin/kafka-topics.sh --create --zookeeper $KAFKA_ZOOKEEPER_CONNECT --replication-factor $REPLICAS --partitions $PARTITION --topic "$TOPICNAME" --config=cleanup.policy=$CLEANUP_POLICY
+        exec $KAFKA_HOME/bin/kafka-topics.sh --create --bootstrap-server $KAFKA_ZOOKEEPER_CONNECT --replication-factor $REPLICAS --partitions $PARTITION --topic "$TOPICNAME" --config=cleanup.policy=$CLEANUP_POLICY
         ;;
     list-topics)
         echo "Listing topics..."
-        exec $KAFKA_HOME/bin/kafka-topics.sh --list --zookeeper $KAFKA_ZOOKEEPER_CONNECT
+        exec $KAFKA_HOME/bin/kafka-topics.sh --list --bootstrap-server $KAFKA_ZOOKEEPER_CONNECT
         ;;
 
 esac

--- a/kafka/1.9/docker-entrypoint.sh
+++ b/kafka/1.9/docker-entrypoint.sh
@@ -165,7 +165,7 @@ case $1 in
                         config="--config=cleanup.policy=${topicConfig[3]}"
                     fi
                     echo "STARTUP: Creating topic ${topicConfig[0]} with ${topicConfig[1]} partitions and ${topicConfig[2]} replicas with cleanup policy ${topicConfig[3]}..."
-                    $KAFKA_HOME/bin/kafka-topics.sh --create --zookeeper $KAFKA_ZOOKEEPER_CONNECT --replication-factor ${topicConfig[2]} --partitions ${topicConfig[1]} --topic "${topicConfig[0]}" ${config}
+                    $KAFKA_HOME/bin/kafka-topics.sh --create --bootstrap-server $KAFKA_ZOOKEEPER_CONNECT --replication-factor ${topicConfig[2]} --partitions ${topicConfig[1]} --topic "${topicConfig[0]}" ${config}
                 done
             )&
         fi
@@ -272,11 +272,11 @@ case $1 in
         fi
         TOPICNAME=$1
         echo "Creating new topic $TOPICNAME with $PARTITION partition(s), $REPLICAS replica(s) and cleanup policy set to $CLEANUP_POLICY..."
-        exec $KAFKA_HOME/bin/kafka-topics.sh --create --zookeeper $KAFKA_ZOOKEEPER_CONNECT --replication-factor $REPLICAS --partitions $PARTITION --topic "$TOPICNAME" --config=cleanup.policy=$CLEANUP_POLICY
+        exec $KAFKA_HOME/bin/kafka-topics.sh --create --bootstrap-server $KAFKA_ZOOKEEPER_CONNECT --replication-factor $REPLICAS --partitions $PARTITION --topic "$TOPICNAME" --config=cleanup.policy=$CLEANUP_POLICY
         ;;
     list-topics)
         echo "Listing topics..."
-        exec $KAFKA_HOME/bin/kafka-topics.sh --list --zookeeper $KAFKA_ZOOKEEPER_CONNECT
+        exec $KAFKA_HOME/bin/kafka-topics.sh --list --bootstrap-server $KAFKA_ZOOKEEPER_CONNECT
         ;;
 
 esac


### PR DESCRIPTION
Since Kafka version 3.0.0 `--zookeeper` flag was removed from Kafka
executables. The option is replaced by `--bootstrap-server`
option [1, 2]. Update docker images entrypoints to use this option.

[1] https://cwiki.apache.org/confluence/display/KAFKA/KIP-604%3A+Remove+ZooKeeper+Flags+from+the+Administrative+Tools
[2] https://issues.apache.org/jira/browse/KAFKA-10104

https://issues.redhat.com/browse/DBZ-4844